### PR TITLE
change site asset stages to match their names with site stage names

### DIFF
--- a/app/views/api/v1/sites/show.json.rabl
+++ b/app/views/api/v1/sites/show.json.rabl
@@ -72,7 +72,7 @@ end
 child :assets do
   attributes :id, :title, :type, :notes
   node(:doc_type) { |asset| Asset::DOC_TYPE[asset.doc_type] }
-  node(:stage) { |asset| Site::STAGE.key(asset.stage).try(:capitalize) }
+  node(:stage) { |asset| Site::STAGE_MAPPING[Site::STAGE.key(asset.stage)] }
   child(:attachments) do
     attributes :id
     node(:file_name) { |attachment| attachment.file_file_name }


### PR DESCRIPTION
The stages associated with assets are not the same as the stages associated with the sites. We should match them on the backend. (Asset stages need to match site stages).

[Story](https://www.pivotaltracker.com/n/projects/1351914/stories/98965636)
