### PR TITLE
Added permision for sales_rep role to read other Users' information

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,6 +373,3 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   unicorn
-
-BUNDLED WITH
-   1.10.2


### PR DESCRIPTION
Very simple oneliner code change on Ability class to allow sales_rep to query other users information as required in bug https://www.pivotaltracker.com/story/show/100069198
